### PR TITLE
Yet another approach to interrupt

### DIFF
--- a/src/main/java/ste/beanshell/BshSession.java
+++ b/src/main/java/ste/beanshell/BshSession.java
@@ -14,84 +14,107 @@ import bsh.Interpreter;
 public class BshSession implements ConsoleInterface, AutoCloseable {
     private static final BshSession instance = new BshSession();
     private Thread t;
-    private Reader  IN;
     private PipedOutputStream OUT;
     public Interpreter bsh;
+
+    /** Private constructor for singleton.
+     * Instantiated by static member instance.*/
     private BshSession() {
         bsh = new Interpreter(this);
-        bsh.setExitOnEOF(false);
     }
 
+    /** Return the singleton reference.
+     * @return BshSession singleton reference. */
     public static BshSession init() {
         return instance;
     }
 
+    /** Start a new interpreter thread.
+     * @return BshSession singleton reference. */
     public BshSession start() {
-        (t = new Thread(bsh)).start();
+        ( t = new Thread(bsh) ).start();
         return instance;
     }
 
+    /** Restart interpreter and thread.
+     * @return BshSession singleton reference. */
     public BshSession restart() {
-        t.interrupt();
-        try {
-            IN.close();
-            IN = null;
-        } catch (IOException e) { /* ignore */ }
-        bsh = new Interpreter(this, bsh.getNameSpace(), bsh);
         bsh.setExitOnEOF(false);
+        bsh.setShowResults(false);
+        bsh.setYieldDelay(1000);
+        this.close();
+        bsh = new Interpreter(this, bsh);
         return this.start();
     }
 
-    public void close() {
-        if (null == t)
-            return;
-        t.interrupt();
-        t = null;
-        try {
-            bsh.setExitOnEOF(true);
-            bsh.close();
-        } catch (IOException e) { /* ignore */ }
-    }
-
+    /** Delegate method for OUT.write().
+     * @param b byte array data to write. */
     public void write(byte b[]) {
         try {
             this.OUT.write(b);
             this.OUT.flush();
-        } catch (IOException e) { e.printStackTrace();/* ignore */ }
+        } catch (IOException e) {
+            System.err.println("BshSession Exception in write: " + e);
+        }
     }
 
+    /** Auto closeable contract method.
+     * {@inheritDoc} */
+    @Override
+    public void close() {
+        t.interrupt();
+        // Avoid close possibly blocking.
+        new Thread(new Runnable() {
+            public void run() {
+                try {
+                  bsh.close();
+                } catch (IOException e) { /* ignore */ }
+            }
+        }).start();
+    }
+
+    /** Called by Interpreter constructor for in reader.
+     * @return new input stream reader instance.
+     * {@inheritDoc} */
     @Override
     public Reader getIn() {
-        if (null == IN) try {
-            IN  = new InputStreamReader(new PipedInputStream(
+        try {
+            return new InputStreamReader(new PipedInputStream(
                     OUT = new PipedOutputStream()));
-        } catch (IOException e) { /* ignore */ }
-        return IN;
+        } catch (IOException e) {
+            System.err.println("BshSession Exception in getIn: " + e);
+            return null;
+        }
     }
 
+    /** {@inheritDoc} */
     @Override
     public PrintStream getOut() {
         return System.out;
     }
 
+    /** {@inheritDoc} */
     @Override
     public PrintStream getErr() {
         return System.err;
     }
 
+    /** {@inheritDoc} */
     @Override
     public void println(Object o) {
         this.getOut().println(o);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void print(Object o) {
         this.getOut().print(o);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void error(Object o) {
-        this.getErr().println(o);
+        this.getErr().print(o);
     }
 
 }


### PR DESCRIPTION
See if you like this better.

I wrapped the Interpreter in a singleton BshSession which has start, restart and close methods. It implements ConsoleInterface which just seems cleaner too.

I made the getBshPrompt command into a static class, see what you think, this might make things easier as well. 

It interrupts multilines without EOF errors and can still interrupt and recover from loops. 

All upto you.

